### PR TITLE
Update bookmarklet link in docs

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -19,7 +19,7 @@
     on <a href="http://phantomjs.org">PhantomJS</a>. Check the <a href="https://github.com/thingsinjars/cssert/blob/master/readme.md">readme</a>
     provided in the project for more information.</p>
     <h2>Bookmarklet</h2>
-    <p class="bookmarklet"><a href="javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://raw.github.com/thingsinjars/cssert/master/lib/generate-tests.js';})();">Generate Tests</a></p>
+    <p class="bookmarklet"><a href="javascript:(function(){document.body.appendChild(document.createElement('script')).src='https://cdn.rawgit.com/thingsinjars/cssert/master/lib/generate-tests.js';})();">Generate Tests</a></p>
     <h2 class="fail">Limitations</h2>
     <p>This isn't any good for Test-Driven Development. Due to CSS and HTML both being declarative, by the time you've written your test case, you'd really have been better off writing the actual HTML. Especially as you could then have used the bookmarklet to generate the test case.</p>
     <p>They may be a point in the future where the visual designer on a project could specify the test case beforehand but until then, this is best used to help with refactoring.</p>


### PR DESCRIPTION
Use [RawGit](https://rawgit.com) to serve external JS file in bookmarklet link.

I get the following error using the current bookmarklet (tested in Chrome 51):

```
Refused to execute script from 'https://raw.github.com/thingsinjars/cssert/master/lib/generate-tests.js' because its MIME type ('text/plain') is not executable, and strict MIME type checking is enabled.
```

Using RawGit should resolve this as the file will be served with the correct MIME type.
